### PR TITLE
fix: add 24h minimum release age for supply chain protection

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
         ":semanticCommitScopeDisabled",
         "schedule:earlyMondays"
     ],
+    "minimumReleaseAge": "1 day",
     "regexManagers": [
         {
             "fileMatch": [


### PR DESCRIPTION
## Summary
- Adds `minimumReleaseAge: "1 day"` to Renovate config

## Why
Supply chain protection. Delays dependency update PRs by 24h after a new version is published, giving the community time to detect and report compromised packages before they're auto-merged.